### PR TITLE
Fix around player → country scope change bugs (Fixes #7)

### DIFF
--- a/ScoreSaber/UI/Leaderboard/ScoreSaberLeaderboardViewController.cs
+++ b/ScoreSaber/UI/Leaderboard/ScoreSaberLeaderboardViewController.cs
@@ -232,7 +232,7 @@ namespace ScoreSaber.UI.Leaderboard {
 
       
 
-                if (scope == PlatformLeaderboardsModel.ScoresScope.AroundPlayer) {
+                if (scope == PlatformLeaderboardsModel.ScoresScope.AroundPlayer && !_filterAroundCountry) {
                     _upButton.interactable = false;
                     _downButton.interactable = false;
                 } else {
@@ -269,7 +269,7 @@ namespace ScoreSaber.UI.Leaderboard {
                     List<LeaderboardTableView.ScoreData> leaderboardTableScoreData = leaderboardData.ToScoreData();
                     int playerScoreIndex = GetPlayerScoreIndex(leaderboardData);
                     if (leaderboardTableScoreData.Count != 0) {
-                        if (scope == PlatformLeaderboardsModel.ScoresScope.AroundPlayer && playerScoreIndex == -1) {
+                        if (scope == PlatformLeaderboardsModel.ScoresScope.AroundPlayer && playerScoreIndex == -1 && !_filterAroundCountry) {
                             SetErrorState(tableView, loadingControl, null, null, "You haven't set a score on this leaderboard");
                         } else {
                             tableView.SetScores(leaderboardTableScoreData, playerScoreIndex);


### PR DESCRIPTION
Changing the scope from "Around me" to the country filtering will result in some inconsistent behavior. None of the scores will load and the up/down arrows on the side on the leaderboard are not properly updated. This is caused by the AroundPlayer hardcodes only checking that the scope matches; however, country filtering is implementing using a bool override for the current scope.

- Add a check that _filterAroundCountry is not true when checking that the scope is "AroundPlayer"

Fixes #7 