### PR TITLE
Add Map Info Modal

### DIFF
--- a/ScoreSaber/UI/Elements/Leaderboard/MapInfoView.cs
+++ b/ScoreSaber/UI/Elements/Leaderboard/MapInfoView.cs
@@ -1,0 +1,118 @@
+﻿using BeatSaberMarkupLanguage.Attributes;
+using HMUI;
+using ScoreSaber.Core.Data.Wrappers;
+using ScoreSaber.Core.Data;
+using ScoreSaber.Core.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScoreSaber.Core.Data.Models;
+using ScoreSaber.Extensions;
+using System.Threading;
+using static StandardScoreSyncState;
+using ScoreSaber.UI.Leaderboard;
+using BeatSaberMarkupLanguage;
+using UnityEngine;
+
+namespace ScoreSaber.UI.Elements.Leaderboard {
+    internal class MapInfoView
+    {
+        #region BSML Components
+        [UIComponent("map-info-modal-root")]
+        public ModalView detailModalRoot = null;
+        [UIComponent("map-name-text")]
+        protected  CurvedTextMeshPro _mapNameText = null;
+        [UIComponent("map-info-top")]
+        protected  ImageView _mapInfoTop = null;
+        [UIComponent("map-info-picture")]
+        protected  ImageView _mapInfoPicture = null;
+        [UIComponent("map-author-text")]
+        protected  CurvedTextMeshPro _mapAuthorText = null;
+        [UIComponent("map-upload-date-text")]
+        protected  CurvedTextMeshPro _mapUploadDateText = null;
+        [UIComponent("map-plays-text")]
+        protected  CurvedTextMeshPro _mapPlaysText = null;
+        [UIComponent("map-status-date-text")]
+        protected  CurvedTextMeshPro _mapStatusDateText = null;
+        [UIComponent("map-info-line-border")]
+        protected  ImageView _mapInfoLineBorder = null;
+
+        #endregion
+
+        internal ScoreSaber.Core.Data.Models.LeaderboardInfo _currentMapInfo { get; set; }
+        internal IDifficultyBeatmap _currentMap { get; set; }
+        internal IReadonlyBeatmapData _currentMapData { get; set; }
+
+        [UIAction("#post-parse")]
+        public void Parsed() {
+            _mapInfoTop.material = Utilities.ImageResources.NoGlowMat;
+
+            var modalPic = _mapInfoPicture;
+            PanelView.ImageSkew(ref modalPic) = 0f;
+            PanelView.ImageSkew(ref _mapInfoLineBorder) = 0f;
+            PanelView.ImageSkew(ref _mapInfoTop) = 0f;
+
+            modalPic.material = Plugin.NoGlowMatRound ?? Resources.FindObjectsOfTypeAll<Material>().Where(m => m.name == "UINoGlowRoundEdge").First();
+        }
+
+        [UIObject("map-info-set")]
+        internal GameObject mapInfoSet = null;
+
+        [UIObject("map-info-set-loading")]
+        internal GameObject mapInfoSetLoading = null;
+
+        [UIAction("map-info-url-click")]
+        public void MapInfoUrlClick() {
+            if (_currentMapInfo == null) return;
+            Application.OpenURL($"https://scoresaber.com/leaderboard/{_currentMapInfo.id}");
+        }
+
+        public void ResetName() {
+            _mapNameText.text = "Loading...";
+        }
+
+        public void SetImage(IDifficultyBeatmap diff) {
+            _mapInfoPicture.sprite = diff.level.GetCoverImageAsync(CancellationToken.None).Result;
+        }
+
+        internal string GetMapStatusString() {
+            bool isRanked = _currentMapInfo.ranked;
+            bool isQualified = _currentMapInfo.qualified;
+            bool isLoved = _currentMapInfo.loved;
+            bool isUnranked = !isRanked && !isQualified && !isLoved;
+
+            if (isRanked)
+                return $"Ranked - (<size=75%><color=#a6a6a6>{(_currentMapInfo.rankedDate.HasValue ? _currentMapInfo.rankedDate.Value.ToString("dd/MM/yy") : string.Empty)}</color></size>) - {_currentMapInfo.stars}<size=70%>★</size>";
+            else if (isQualified)
+                return $"Qualified - (<size=75%><color=#a6a6a6>{(_currentMapInfo.qualifiedDate.HasValue ? _currentMapInfo.qualifiedDate.Value.ToString("dd/MM/yy") : string.Empty)}</color></size>)";
+            else if (isLoved)
+                return $"Loved - (<size=75%><color=#a6a6a6>{(_currentMapInfo.lovedDate.HasValue ? _currentMapInfo.lovedDate.Value.ToString("dd/MM/yy") : string.Empty)}</color></size>)";
+            else if (isUnranked)
+                return $"Unranked";
+            else
+                return string.Empty;
+        }
+
+        public void SetScoreInfo(Core.Data.Models.LeaderboardInfo mapInfo) {
+            if (mapInfo == null || _currentMap == null) return;
+            try {
+                _currentMapInfo = mapInfo;
+                _mapNameText.text = $"Map Details: {mapInfo.songName}";
+                SetImage(_currentMap);
+                _mapAuthorText.text = $"Mapped By {mapInfo.levelAuthorName}";
+                _mapUploadDateText.SetFancyText("Uploaded", $"{mapInfo.createdDate:dd/MM/yy}");
+                _mapPlaysText.SetFancyText("Plays", $"{mapInfo.plays} ({mapInfo.dailyPlays} Last 24h)");
+                _mapStatusDateText.SetFancyText("Status", $"{GetMapStatusString()}");
+                mapInfoSetLoading.gameObject.SetActive(false);
+                mapInfoSet.SetActive(true);
+            } catch (Exception e) {
+                mapInfoSetLoading.gameObject.SetActive(true);
+                mapInfoSet.SetActive(false);
+                Plugin.Log.Error(e);
+            }
+        }
+
+    }
+}

--- a/ScoreSaber/UI/Leaderboard/PanelView.bsml
+++ b/ScoreSaber/UI/Leaderboard/PanelView.bsml
@@ -12,7 +12,7 @@
     </vertical>
     <vertical active="~is-loaded" pref-width="60" pref-height="10" spacing="-1">
       <clickable-text text="~global-leaderboard-ranking" on-click="clicked-ranking" font-size="3.5" overflow-mode="Ellipsis" italics="true" align="Left" />
-      <clickable-text text="~leaderboard-ranked-status" on-click="clicked-status" font-size="3.5" overflow-mode="Ellipsis" italics="true" align="Left" hover-hint="Opens in browser" />
+      <clickable-text text="~leaderboard-ranked-status" on-click="clicked-status" font-size="3.5" overflow-mode="Ellipsis" italics="true" align="Left" hover-hint="Opens the map info modal" />
     </vertical>
     <horizontal active="~is-loading" pref-width="60" pref-height="10">
       <vertical pref-width="60" pref-height="10">

--- a/ScoreSaber/UI/Leaderboard/ScoreSaberLeaderboardViewController.bsml
+++ b/ScoreSaber/UI/Leaderboard/ScoreSaberLeaderboardViewController.bsml
@@ -67,6 +67,46 @@
 			</vertical>
 		</macro.as-host>
 	</modal>
+	
+	<!-- map info modal -->
+	<modal id="map-info-modal-root" show-event="present-map-info" clickerino-offerino-closerino="true" hide-event="close-modals" size-delta-x="90" size-delta-y="50">
+		<macro.as-host host="map-info-view">
+			<vertical child-control-height="false" spacing="1" pref-height="50" horizontal-fit="PreferredSize" vertical-fit="PreferredSize" bg="round-rect-panel" bg-color="#69696999">
+				<horizontal id="map-info-top" bg="round-rect-panel" bg-color="#555EBC" horizontal-fit="PreferredSize" vertical-fit="PreferredSize" anchor-pos-y="1" pref-width="90" size-delta-x="90">
+					<horizontal horizontal-fit="PreferredSize" vertical-fit="PreferredSize" spacing="2" child-align="MiddleCenter">
+						<clickable-text id="map-name-text" text="Loading..." align="Center" anchor-pos-y="20" font-size="5" size-delta-y="6" size-delta-x="45" overflow-mode="Ellipsis" on-click="map-info-url-click" hover-hint="Opens in browser" />
+					</horizontal>
+				</horizontal>
+				<horizontal id="map-info-set" pref-width="90" pref-height="40" spacing="2">
+					<vertical horizontal-fit="PreferredSize" pref-width="35">
+						<vertical pad-left="2" pref-width="35">
+							<img id="map-info-picture" preserve-aspect="true" />
+						</vertical>
+						<text id="map-author-text" text="Loading..." align="Center" overflow-mode="Ellipsis"/>
+					</vertical>
+					<vertical pref-width=".75" pref-height="40">
+						<img id="map-info-line-border" src="ScoreSaber.Resources.pixel.png" size-delta-x=".75" size-delta-y="45" />
+					</vertical>
+					<vertical pref-width="40" pref-height="45" pad="2">
+						<vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize" size-delta-x="50" size-delta-y="45" >
+							<vertical vertical-fit="PreferredSize" pref-width="45" pref-height="10">
+								<text id="map-upload-date-text" text="Upload Date:"  align="Left" size-delta-y="4" />
+							</vertical>
+							<vertical vertical-fit="PreferredSize" pref-width="45" pref-height="10">
+								<text id="map-status-date-text" text="Ranking Date:" align="Left" size-delta-y="4" />
+							</vertical>
+							<vertical vertical-fit="PreferredSize" pref-width="45" pref-height="10">
+								<text id="map-plays-text" text="Plays:" align="Left" size-delta-y="4" />
+							</vertical>
+						</vertical>
+					</vertical>
+				</horizontal>
+				<horizontal id="map-info-set-loading">
+					<loading-indicator preserve-aspect="true"/>
+				</horizontal>
+			</vertical>
+		</macro.as-host>
+	</modal>
 
 	<!-- Profile modal -->
 	<ss-profile id="profile-detail-view" show-event="show-profile" loading="false" />


### PR DESCRIPTION
## Makes the Ranked Status text open a modal that displays general map info that you would normally have to see on the website

### [Feature idea from Sync](https://twitter.com/sync_bs/status/1562789393386971140)

<img src="https://github.com/ScoreSaber/scoresaber-plugin/assets/90689870/96a5289c-e0dd-4b96-a8da-f25ab5cf7cf4" width="500" />
<img src="https://github.com/ScoreSaber/scoresaber-plugin/assets/90689870/1e45610f-418e-408a-af05-420540887436" width="500" />
<img src="https://github.com/ScoreSaber/scoresaber-plugin/assets/90689870/e92879b8-6bd0-4a54-9ab1-275fd1dde83e" width="500" />